### PR TITLE
성경님 이거 풀 받으시기전에 읽어주세요

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.5.0'
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.5.0'
-
-
-
 }
 
 test {

--- a/src/main/java/com/sparta/todayrecipe/configuration/WebConfig.java
+++ b/src/main/java/com/sparta/todayrecipe/configuration/WebConfig.java
@@ -1,13 +1,31 @@
 package com.sparta.todayrecipe.configuration;
 
+import org.apache.tomcat.util.http.Rfc6265CookieProcessor;
+import org.apache.tomcat.util.http.SameSiteCookies;
+import org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import javax.servlet.http.Cookie;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**").allowedOrigins("http://localhost:3000").allowedMethods("POST","GET","PUT","DELETE","HEAD","OPTIONS").allowCredentials(true);
+        registry.addMapping("/**")
+                .allowedOrigins("http://blossomwhale.shop")
+                .allowedMethods("POST","GET","PUT","DELETE","HEAD","OPTIONS")
+                .allowCredentials(true);
+    }
+
+    @Bean
+    public TomcatContextCustomizer sameSiteCookiesConfig() {
+        return context -> {
+            final Rfc6265CookieProcessor cookieProcessor = new Rfc6265CookieProcessor();
+            cookieProcessor.setSameSiteCookies(SameSiteCookies.NONE.getValue());
+            context.setCookieProcessor(cookieProcessor);
+        };
     }
 }

--- a/src/main/java/com/sparta/todayrecipe/security/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/todayrecipe/security/WebSecurityConfig.java
@@ -1,26 +1,12 @@
 package com.sparta.todayrecipe.security;
 
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity // 스프링 Security 지원을 가능하게 함
@@ -50,16 +36,16 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .formLogin()
                 .loginPage("/user/login")
                 .loginProcessingUrl("/user/login")
+                .successHandler((request, response, authentication) -> {
+                })
 //                .defaultSuccessUrl("/")
 //                .failureUrl("/user/login/error")
-                .successHandler((request, response, authentication) -> {
-                    //do nothing
-                })
                 .permitAll()
                 .and()
                 .logout()
-                .logoutUrl("/user/logout")
-                .permitAll();
+                .logoutUrl("/user/logout").permitAll()
+                .logoutSuccessHandler((request, response, authentication) -> {
+                });
     }
     @Bean
     public BCryptPasswordEncoder encodePassword() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,23 +1,27 @@
 spring.jpa.show-sql=true
-spring.datasource.url=jdbc:mysql://springboot-db.cfxeyq2zcn3r.ap-northeast-2.rds.amazonaws.com:3306/todayrecipe
-spring.datasource.username=code_angler
-spring.datasource.password=test0099
+#spring.datasource.url=jdbc:mysql://springboot-db.cfxeyq2zcn3r.ap-northeast-2.rds.amazonaws.com:3306/todayrecipe
+#spring.datasource.username=code_angler
+#spring.datasource.password=test0099
 spring.jpa.hibernate.ddl-auto=update
 
 ### 타임리프 관련 ###
 spring.thymeleaf.prefix=classpath:/static/
 
 # H2 DB 관련
-#spring.h2.console.enabled=true
-#spring.datasource.driverClassName=org.h2.Driver
+spring.h2.console.enabled=true
+spring.datasource.driverClassName=org.h2.Driver
 #spring.datasource.url=jdbc:h2:mem:todayrecipedb
 ### 추후 h2서버를 로컬로 관리할 때 사용(서버 리스타트 해도 db 안사라지게) ###
-#spring.datasource.url=jdbc:h2:./todayrecipedb;AUTO_SERVER=TRUE
-#spring.datasource.username=sa
-#spring.datasource.password=
+spring.datasource.url=jdbc:h2:./todayrecipedb;AUTO_SERVER=TRUE
+spring.datasource.username=sa
+spring.datasource.password=
 
 # hibernate 관련
 #spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=debug
 logging.level.org.hibernate.type.descriptor.sql=trace
+
+server.servlet.session.cookie.secure=true
+#server.servlet.session.cookie.path=
+#server.servlet.session.cookie.domain=http://blossomwhale.shop


### PR DESCRIPTION
WebConfig.java sameSite = none 해주는 tomcat handler 추가
WebSecurity.java loginSuccessHandler와 logOutSuccessHandler 빈 값으로 설정하여, 리디렉션 없도록 함
=========================================================

현재, 클라이언트서버랑 백서버 분리해서 테스트했는데 로그인, 로그인확인, 해당 로그인 유저가 특정 comment에 대해 put 요청까지 성공하는것 확인했구요. JSESSIONID는 클라이언트서버에 저장되는것이 아닌, 백서버에 저장되는게 맞아요. 따라서 크롬으로 성경님 서버 URL로 접근해야 해당 cookie에 접근 할 수 있어요. 이대로 돌리면 사실상 돌아가는게 맞지만, 좀 찝찝함들이 남아있는게 사실이라 jwtToken이 구현되면 그걸로 해결하는것도 좋다고 생각해요.

참고로, 해당 프로젝트를 구동시키려면, WebConfig에 allowwedOrigins를 현재 blossomwhale.shop으로 되어있는걸 클라이언트 서버 주소로 바꿔야 해요,
그리고 클라이언트 측에서는 요청시 전부 credential을 붙여줘야되는데, axios는 잘 모르지만, 승규님이랑 아까 잠깐 credential 관련해서 얘기하기도 했구요, 말씀하시면 아마 알아들으실 거에요, 제가 테스트할때 썼던 js 문법이긴한데 이게 도움이 될지 몰라서 이것도 남길게요.
[js 쿼리.txt](https://github.com/Code-Angler/TodayRecipe/files/6803795/js.txt)
여기에서 withCredential = true가 해당 설정값인데, axios에선 어떻게되는지 승규님이 아실거에요...
제가 혹시 조금 늦게 일어날수도있어서 메모...남깁니다...

